### PR TITLE
fixed reference to the cloudify-resources repo to be cloned

### DIFF
--- a/apps/travel-chef/chef-server/chef_server_loadCookbooks.sh
+++ b/apps/travel-chef/chef-server/chef_server_loadCookbooks.sh
@@ -31,7 +31,7 @@ $SUDO chown `whoami` ~/.chef/chef-webui.pem
 if [[ -d $HOME/cloudify-recipes/.git ]]; then
     cd $HOME/cloudify-recipes; git pull origin master; cd -
 else
-    git clone https://github.com/yoniYalovitsky/cloudify-recipes.git $HOME/cloudify-recipes
+    bash clone_cloudify_recipes.sh $HOME/cloudify-recipes
 fi
 
 [[ -r $HOME/cookbooks ]] || ln -s $HOME/cloudify-recipes/apps/travel-chef/cookbooks $HOME/cookbooks

--- a/apps/travel-chef/chef-server/clone_cloudify_recipes.sh
+++ b/apps/travel-chef/chef-server/clone_cloudify_recipes.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+#This command has been split off from chef_server_loadCookbooks to allow testing the code from a fork.
+TARGET_DIR=$1
+git clone https://github.com/CloudifySource/cloudify-recipes.git $TARGET_DIR


### PR DESCRIPTION
The repo cloned by the chef-server app to get its cookbooks was my debugging repo. I returned it to be CloudifySource, and from now on I'll debug by changing the separate file, which I've excluded from pushing.
Yoni.
