### PR TITLE
Use SSL for downloading Chef Omnibus install.sh script

### DIFF
--- a/services/chef/chef.properties
+++ b/services/chef/chef.properties
@@ -1,6 +1,6 @@
 unix {
     installDir="/tmp/chef_install"
-    scriptUrl="http://www.opscode.com/chef/install.sh"
+    scriptUrl="https://www.opscode.com/chef/install.sh"
     installer="install.sh"
     solo.bin="/usr/bin/chef-solo"
     client.bin="/usr/bin/chef-client"
@@ -9,7 +9,7 @@ unix {
 }
 win32 {
     installDir="C:\\cloudify\\temp"
-    scriptUrl="http://www.opscode.com/chef/install.msi"
+    scriptUrl="https://www.opscode.com/chef/install.msi"
     installer="install.msi"
 }
 


### PR DESCRIPTION
Using SSL will help protect against a MITM attack when downloading this script.
