### PR TITLE
Bumped chef version number up in order to deal with issues related to CHEF-3721

### DIFF
--- a/services/chef/chef.properties
+++ b/services/chef/chef.properties
@@ -30,7 +30,7 @@ win32 {
 
 chef {
     installFlavor = "gem"
-    version = "10.12.0"
+    version = "10.16.4"
     bootstrapCookbooksUrl="http://repository.cloudifysource.org/chef-cookbooks/bootstrap-cookbooks.tar.gz"
     serverURL = ""
     validationCert = """


### PR DESCRIPTION
A chef dependency (i.e. moneta - see http://tickets.opscode.com/browse/CHEF-3721) breaks cloudify deployments using chef. 

This has been fixed in version 10.16.4 and 10.18.0 of chef - hence a version bump in chef.properties.
