### PR TITLE
workaround for gem installation on RHEL/CentOS

### DIFF
--- a/services/chef/ChefBootstrap.groovy
+++ b/services/chef/ChefBootstrap.groovy
@@ -250,7 +250,8 @@ class RHELBootstrap extends ChefBootstrap {
         sudo("yum install -y ${pkgs.join(" ")}")
     }
     def gemInstall() {
-        sudo("gem update --system")
+	// workaround - at least on CentOS6.3 gem updates to v2.0.0 here, breaking rubygems dependencies
+        sudo("gem update --system 1.8.25")
         super.gemInstall()
     }
 }


### PR DESCRIPTION
On at least RHEL/CentOS 6.3, the "gem update --system" results in a v2.0.0 gem installation.
This breaks dependencies with rubygems already installed as part of chef-service.

This is a temporary workaround to install the highest pre-2.0.0 version, namely 1.8.25.

Issue on Cloudify Jira:
https://cloudifysource.atlassian.net/browse/CLOUDIFY-1543
