### PR TITLE
CLOUDIFY-1543

### DIFF
--- a/services/chef/ChefBootstrap.groovy
+++ b/services/chef/ChefBootstrap.groovy
@@ -250,7 +250,8 @@ class RHELBootstrap extends ChefBootstrap {
         sudo("yum install -y ${pkgs.join(" ")}")
     }
     def gemInstall() {
-        sudo("gem update --system")
+	// workaround - at least on CentOS6.3 gem updates to v2.0.0 here, breaking rubygems dependencies
+        sudo("gem update --system 1.8.25")
         super.gemInstall()
     }
 }

--- a/services/chef/ChefBootstrap.groovy
+++ b/services/chef/ChefBootstrap.groovy
@@ -250,8 +250,9 @@ class RHELBootstrap extends ChefBootstrap {
         sudo("yum install -y ${pkgs.join(" ")}")
     }
     def gemInstall() {
-	// workaround - at least on CentOS6.3 gem updates to v2.0.0 here, breaking rubygems dependencies
-        sudo("gem update --system 1.8.25")
+        //on RHEL based systems, we want to force a specific RubyGems version
+        //to avoid breaking rubygems dependencies
+        sudo("gem update --system ${chefConfig.rubyGemsVersion}")
         super.gemInstall()
     }
 }

--- a/services/chef/chef.properties
+++ b/services/chef/chef.properties
@@ -37,5 +37,6 @@ chef {
     """
     // runList = []
     initStyle = "bluepill"
+    rubyGemsVersion = "1.8.24"
     gemTarballUrl = "http://production.cf.rubygems.org/rubygems/rubygems-1.8.24.tgz"
 }


### PR DESCRIPTION
Adapting Dan Garton's fix to keep the version in properties file instead of hard-coded.

Also, avoided bumping the RubyGems version from 1.8.24 to 1.8.25 until
further testing. In any case, I suggest we switch to using  the same version on
all distros.
