### PR TITLE
Chef 11

### DIFF
--- a/services/chef-server/Berksfile
+++ b/services/chef-server/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+cookbook "chef-server", github:"opscode-cookbooks/chef-server"

--- a/services/chef-server/README.md
+++ b/services/chef-server/README.md
@@ -2,6 +2,11 @@
 
 Installs the open source Chef server using Chef-Solo. 
 
+## Supported platforms
+
+chef-server does not support 32bit OS. Make sure you assign a proper image in your recipe. The default image in this recipe is not defined in default cloud recipes!
+Currently there is a bug in Opscode's Omnitruck download API when using Amazon Linux.
+
 > *Important*: Currently the chef recipes have only been tested on an Ubuntu environment on Amazon EC2. Please make sure to use the [EC2 ubuntu cloud driver](https://github.com/CloudifySource/cloudify-cloud-drivers/tree/master/ec2-ubuntu) when installing services or applications that are based on this recipe
 
 

--- a/services/chef-server/chef-server-service.groovy
+++ b/services/chef-server/chef-server-service.groovy
@@ -24,42 +24,37 @@ service {
 	numInstances 1
 
     compute {
-        template "SMALL_UBUNTU"
+        template "MEDIUM_LINUX"
     }
 
 	lifecycle{
         start {
-            def bootstrap = ChefBootstrap.getBootstrap(installFlavor:"gem", context:context)
-            def config = bootstrap.getConfig()
+            // chefServerVersion is defined in properties file
+            def bootstrap = ChefBootstrap.getBootstrap(installFlavor:"fatBinary", context:context)
+            bootstrap.runApply("""package \"git\"""")
             bootstrap.runSolo([
-                "chef_server": [
-                    "server_url": "http://localhost:4000",
-                    "init_style": "${config.initStyle}"
+                "chef-server": [
+                    "version": "${chefServerVersion}"
                 ],
-                "chef_packages": [
-                    "chef": [
-                        "version": "${config.version}"
-                    ]
-                ],
-                "run_list": ["recipe[build-essential]", "recipe[chef-server::rubygems-install]", "recipe[chef-server::apache-proxy]" ]
+                "run_list": ["recipe[chef-server]"]
             ])
 
             //setting the global attributes to be available for all chef clients  
             def privateIp = System.getenv()["CLOUDIFY_AGENT_ENV_PRIVATE_IP"]
-            def serverUrl = "http://${privateIp}:4000" as String
+            def serverUrl = "https://${privateIp}:443" as String
             context.attributes.global["chef_validation.pem"] = sudoReadFile("/etc/chef/validation.pem")
             context.attributes.global["chef_server_url"] = serverUrl
         }
 		
 		startDetectionTimeoutSecs 600
 		startDetection {
-			ServiceUtils.isPortOccupied(4000)
+			ServiceUtils.isPortOccupied(443)
 		}
 		
 		details {
 			def publicIp = System.getenv()["CLOUDIFY_AGENT_ENV_PUBLIC_IP"]
 			def serverRestUrl = "https://${publicIp}:443"
-			def serverUrl = "http://${publicIp}:4000"
+			def serverUrl = "https://${publicIp}:443"
     		return [
     			"Rest URL":"<a href=\"${serverRestUrl}\" target=\"_blank\">${serverRestUrl}</a>",
     			"Server URL":"<a href=\"${serverUrl}\" target=\"_blank\">${serverUrl}</a>"

--- a/services/chef-server/chef-server-service.groovy
+++ b/services/chef-server/chef-server-service.groovy
@@ -24,7 +24,7 @@ service {
 	numInstances 1
 
     compute {
-        template "MEDIUM_LINUX"
+        template "SMALL_LINUX_x64" // Chef server does not support 32bit
     }
 
 	lifecycle{

--- a/services/chef/chef-service.groovy
+++ b/services/chef/chef-service.groovy
@@ -26,7 +26,7 @@ service {
 
     lifecycle {
         install {
-            ChefBootstrap.getBootstrap(context: context, installFlavor: "gem").install()
+            ChefBootstrap.getBootstrap(context: context).install() // default installation method defined in chef.properties
         }
         start {
             def chefServerURL = context.attributes.global["chef_server_url"]

--- a/services/chef/chef.properties
+++ b/services/chef/chef.properties
@@ -24,14 +24,14 @@ unix {
 }
 win32 {
     installDir="C:\\cloudify\\temp"
-    scriptUrl="https://www.opscode.com/chef/install.msi"
-    installer="install.msi"
+    scriptUrl="https://opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chef-client-11.4.4-1.windows.msi"
+    installer="chef-client-11.4.4-1.msi"
 }
 
 chef {
-    installFlavor = "gem"
-    version = "10.16.4"
-    bootstrapCookbooksUrl="http://repository.cloudifysource.org/chef-cookbooks/bootstrap-cookbooks.tar.gz"
+    installFlavor = "fatBinary"
+    version = "11.4.4-1"
+    // bootstrapCookbooksUrl="http://repository.cloudifysource.org/chef-cookbooks/bootstrap-cookbooks.tar.gz"
     serverURL = ""
     validationCert = """
     """


### PR DESCRIPTION
Chef 11 support for cloudify integration.

New features:
chef-server 11, now supports CentOS/RedHat. Amazon linux support pending due to Opscode bug.
chef-apply - you can now apply arbitrary chef code directly from Cloudify recipes
Berkshelf support - drop a Berksfile in service recipe directory and Cloudify will auto fetch your cookbooks

Changes:
fatBinary is now the default install method.
Default chef version is 11.4.4-1
