### PR TITLE
Chef recipe

### DIFF
--- a/services/chef-server/Shell.groovy
+++ b/services/chef-server/Shell.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 GigaSpaces Technologies Ltd. All rights reserved
+ * Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ def static startProcess(command, Map env=[:]) {
 }
 // overload shellify to handle different types
 def static shellify_cmd(java.util.ArrayList command) {
+    // TODO: we should add quote to protect each word
     return ["/bin/sh", "-c", command.join(" ")]
 }
 
@@ -93,6 +94,7 @@ def static sudo(command, Map opts=[:]) {
 }
 
 def static sudo(java.util.ArrayList command, Map opts=[:]) {
+    // TODO: we should add quotes to protect each word
     return sudo(command.join(" "), opts)
 }
 

--- a/services/chef-server/chef-server-service.groovy
+++ b/services/chef-server/chef-server-service.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2012 GigaSpaces Technologies Ltd. All rights reserved
+* Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,53 +18,56 @@ import static ChefLoader
 
 service {
     extend "../chef"
-	name "chef-server"
-	type "WEB_SERVER"
-	icon "chef.png"
-	numInstances 1
+    name "chef-server"
+    type "WEB_SERVER"
+    icon "chef.png"
+    numInstances 1
 
     compute {
         template "SMALL_UBUNTU"
     }
 
-	lifecycle{
+    lifecycle{
         start {
             def bootstrap = ChefBootstrap.getBootstrap(installFlavor:"gem", context:context)
             def config = bootstrap.getConfig()
-            bootstrap.runSolo([
-                "chef_server": [
-                    "server_url": "http://localhost:4000",
-                    "init_style": "${config.initStyle}"
-                ],
-                "chef_packages": [
-                    "chef": [
-                        "version": "${config.version}"
+            bootstrap.runSolo(
+                ["recipe[build-essential]", "recipe[chef-server::rubygems-install]", "recipe[chef-server::apache-proxy]" ], 
+                [
+                    "chef_server": [
+                        "server_url": "http://localhost:4000",
+                        "init_style": "${config.initStyle}"
+                    ],
+                    "chef_packages": [
+                        "chef": [
+                            "version": "${config.version}"
+                        ]
                     ]
-                ],
-                "run_list": ["recipe[build-essential]", "recipe[chef-server::rubygems-install]", "recipe[chef-server::apache-proxy]" ]
-            ])
+                ]
+            )
 
             //setting the global attributes to be available for all chef clients  
-            def privateIp = System.getenv()["CLOUDIFY_AGENT_ENV_PRIVATE_IP"]
+            def privateIp = context.privateAddress
             def serverUrl = "http://${privateIp}:4000" as String
             context.attributes.global["chef_validation.pem"] = sudoReadFile("/etc/chef/validation.pem")
             context.attributes.global["chef_server_url"] = serverUrl
+            return null
         }
-		
-		startDetectionTimeoutSecs 600
-		startDetection {
-			ServiceUtils.isPortOccupied(4000)
-		}
-		
-		details {
-			def publicIp = System.getenv()["CLOUDIFY_AGENT_ENV_PUBLIC_IP"]
-			def serverRestUrl = "https://${publicIp}:443"
-			def serverUrl = "http://${publicIp}:4000"
-    		return [
-    			"Rest URL":"<a href=\"${serverRestUrl}\" target=\"_blank\">${serverRestUrl}</a>",
-    			"Server URL":"<a href=\"${serverUrl}\" target=\"_blank\">${serverUrl}</a>"
-    		]
-    	}
+        
+        startDetectionTimeoutSecs 600
+        startDetection {
+            ServiceUtils.isPortOccupied(4000)
+        }
+        
+        details {
+            def publicIp = context.publicAddress
+            def serverRestUrl = "https://${publicIp}:443"
+            def serverUrl = "http://${publicIp}:4000"
+            return [
+                "Rest URL":"<a href=\"${serverRestUrl}\" target=\"_blank\">${serverRestUrl}</a>",
+                "Server URL":"<a href=\"${serverUrl}\" target=\"_blank\">${serverUrl}</a>"
+            ]
+        }
         postStart { 
             if (binding.variables["chefRepo"]) {
                 chef_loader = ChefLoader.get_loader(chefRepo.repo_type)
@@ -77,6 +80,8 @@ service {
         }
     }
 
+    // TODO: improve updateCookbooks with a try/catch (sh can throw an exception that is not printed)
+    // TODO: improve listCookbooks and knife to print eventual error (shellout prints no error)
     customCommands([
         "updateCookbooks": { repo_type="git",
                              url="by default, the existing repo will be reused",
@@ -97,7 +102,5 @@ service {
             chef_loader = ChefLoader.get_loader()
             return chef_loader.invokeKnife(args)
         }
-
-
     ])
 }

--- a/services/chef/Shell.groovy
+++ b/services/chef/Shell.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 GigaSpaces Technologies Ltd. All rights reserved
+ * Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ def static startProcess(command, Map env=[:]) {
 }
 // overload shellify to handle different types
 def static shellify_cmd(java.util.ArrayList command) {
+    // TODO: we should add quote to protect each word
     return ["/bin/sh", "-c", command.join(" ")]
 }
 
@@ -93,6 +94,7 @@ def static sudo(command, Map opts=[:]) {
 }
 
 def static sudo(java.util.ArrayList command, Map opts=[:]) {
+    // TODO: we should add quotes to protect each word
     return sudo(command.join(" "), opts)
 }
 

--- a/services/chef/chef-service.properties
+++ b/services/chef/chef-service.properties
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2012 GigaSpaces Technologies Ltd. All rights reserved
+* Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/services/chef/run_cucumber.sh
+++ b/services/chef/run_cucumber.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
-cd /home/ubuntu/cucumber
+#!/bin/sh -e
+cd ./cucumber
 jruby -S cucumber
-exit 0 #hack - to see the error text, we must exit successfully(CLOUDIFY-915)


### PR DESCRIPTION
Improve the integration with Chef.
The new recipe don't force to get chef url from the globaal context (so the inherited recipe can provide this url by another way, it is usefull if we don't rely on a chef server deployed by cloudify)
The new recipe save runParams in the context. And we restore it in case of self-healing).
We add a custom command named 'rerun' that re-execute the chef-client, useful after an update of the runParams.
