### PR TITLE
workaround for chef split horizon dns - CHEF-4086

### DIFF
--- a/apps/travel-chef/chef-server/chef-server-service.properties
+++ b/apps/travel-chef/chef-server/chef-server-service.properties
@@ -20,3 +20,7 @@ chefRepo = [
 ]
 
 chefServerVersion="11.0.8-1"
+
+//This can be enabled when the hostname returned by the chef-server is externally routable (e.g. in AWS machines), and will allow use of the chef server outside the current deployment.
+//If left unset, the chef-server will be configured to use its internal ip, and will only be accessible by instances in its local availability zone.
+externallyRoutableHostname = false

--- a/services/chef-server/chef-server-service.properties
+++ b/services/chef-server/chef-server-service.properties
@@ -1,1 +1,5 @@
 chefServerVersion = "11.0.8-1"
+
+//This can be enabled when the hostname returned by the chef-server is externally routable (e.g. in AWS machines), and will allow use of the chef server outside the current deployment.
+//If left unset, the chef-server will be configured to use its internal ip, and will only be accessible by instances in its local availability zone.
+externallyRoutableHostname = false


### PR DESCRIPTION
I added the flag property externallyRoutableHostname to chef-server defaulting to false. When false, we now configure chef-server to give out its private ip to clients so that it'll work correctly when not routable from outside networks. But if a client plans to use the chef server for machines outside the cloudify deployment, they will know need to enable this property.
Tested on hp and ec2.
This property can be safely enabled on ec2, but can't be easily enabled on current versions of hp or rackspace.
