### PR TITLE
Add stop iptables to the installation phase

### DIFF
--- a/services/biginsights/data/set_ssh_key.sh
+++ b/services/biginsights/data/set_ssh_key.sh
@@ -5,6 +5,7 @@ if [[ $EUID -ne 0 ]]; then
 	if [ ! -d ~root/.ssh ]; then
 		sudo mkdir ~root/.ssh
 	fi		
+	sudo /etc/init.d/iptables stop
 	sudo sed -i 's/^PermitRootLogin.*no/PermitRootLogin yes/g' /etc/ssh/sshd_config
 	sudo cp ./id_rsa ~root/.ssh/id_rsa
 	sudo sudo chmod 600 ~root/.ssh/id_rsa
@@ -39,6 +40,7 @@ else
 	if [ ! -d ~/.ssh ]; then
 		mkdir ~/.ssh
 	fi	
+	/etc/init.d/iptables stop
 	sed -i 's/^PermitRootLogin.*no/PermitRootLogin yes/g' /etc/ssh/sshd_config
 	echo about to create passwordless SSH access
 	cp ./id_rsa ~root/.ssh/id_rsa

--- a/services/biginsights/master/set_ssh_key.sh
+++ b/services/biginsights/master/set_ssh_key.sh
@@ -4,7 +4,8 @@ if [[ $EUID -ne 0 ]]; then
 	echo "Not root, need sudo"		
 	if [ ! -d ~root/.ssh ]; then
 		sudo mkdir ~root/.ssh
-	fi		
+	fi
+    sudo /etc/init.d/iptables stop
 	sudo sed -i 's/^PermitRootLogin.*no/PermitRootLogin yes/g' /etc/ssh/sshd_config
 	sudo cp ./id_rsa ~root/.ssh/id_rsa
 	sudo sudo chmod 600 ~root/.ssh/id_rsa
@@ -20,7 +21,8 @@ if [[ $EUID -ne 0 ]]; then
 else
 	if [ ! -d ~/.ssh ]; then
 		mkdir ~/.ssh
-	fi	
+	fi
+    /etc/init.d/iptables stop
 	sed -i 's/^PermitRootLogin.*no/PermitRootLogin yes/g' /etc/ssh/sshd_config
 	cp ./id_rsa ~root/.ssh/id_rsa
 	chmod 600 ~root/.ssh/id_rsa


### PR DESCRIPTION
This is needed since BigInsights checks all different ports before it install the software.
Prior to the change, this was done in the bootstrap management script.
