### PR TITLE
Changed puppet integration

### DIFF
--- a/services/puppet-agent/puppet-agent-service.groovy
+++ b/services/puppet-agent/puppet-agent-service.groovy
@@ -1,0 +1,13 @@
+
+service { 
+    extend "../puppet"
+    name "puppet-agent"
+    icon "puppet.png"
+
+    customCommands([
+        "run_agent": { tags ->
+            tagAry = tags.any() ? tags.split(",") : []
+            PuppetBootstrap.getBootstrap(context:context).puppetAgent(tagAry)
+        }
+    ])
+}

--- a/services/puppet-agent/puppet-agent-service.properties
+++ b/services/puppet-agent/puppet-agent-service.properties
@@ -1,0 +1,4 @@
+puppetMode = "agent"
+puppetMasterIp = "puppetservercloud.dc2"
+puppetEnvironment = "pcha_cloudify"
+

--- a/services/puppet/custom_facts/cloudify_facts.rb
+++ b/services/puppet/custom_facts/cloudify_facts.rb
@@ -22,6 +22,7 @@ attributes = {}
 }.each do |category, resource|
     attributes.merge!({category => get_json(resource)})
 end
+attributes.merge!("cloudify" => @metadata)
 
 class Hash
     def flatten_to_hash(current_prefix="", separator="_")

--- a/services/puppet/puppet.properties
+++ b/services/puppet/puppet.properties
@@ -24,7 +24,7 @@ win32 {
 
 puppet {
     installFlavor = "packages"
-    version = "3.0.0"
+    version = "3.1.1-1puppetlabs1"
     server = ""
     environment = "cloudify"
     puppetlabsRepoRpm { 
@@ -38,7 +38,7 @@ puppet {
         maverick = "http://apt.puppetlabs.com/puppetlabs-release-maverick.deb"
         natty    = "http://apt.puppetlabs.com/puppetlabs-release-natty.deb"
         oneiric  = "http://apt.puppetlabs.com/puppetlabs-release-oneiric.deb"
-        precise  = "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"
+        precise  = "http://repo/other/puppet/puppet-repo.deb"
         quantal  = "http://apt.puppetlabs.com/puppetlabs-release-quantal.deb"
         sid      = "http://apt.puppetlabs.com/puppetlabs-release-sid.deb"
         squeeze  = "http://apt.puppetlabs.com/puppetlabs-release-squeeze.deb"

--- a/services/puppet/templates/puppet.conf
+++ b/services/puppet/templates/puppet.conf
@@ -10,3 +10,5 @@
 
 [agent]
     server = ${server}
+    certname = ${ new java.text.SimpleDateFormat("yyyyMMddHHmm").format(new Date()) }-${nodeName}
+    node_name_value = ${nodeName}


### PR DESCRIPTION
Puppet integration can work now with puppet external classifier plugin.

The puppet.conf file which is used to interact with the puppet master server is being created by the PuppetBootstrap.groovy file using the puppet.conf template. One should change to use the required convention according the the puppet master.
