### PR TITLE
Fix Redis service to use the latest version and to work on OS X

### DIFF
--- a/services/redis/redis-service.properties
+++ b/services/redis/redis-service.properties
@@ -13,10 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-version = "2.4.5"
+version = "2.8.6"
 name = "redis-${version}"
 zipName = "${name}.tar.gz"
 installDir = "install"
-downloadPath = "http://redis.googlecode.com/files/${zipName}"
+downloadPath = "http://download.redis.io/releases/${zipName}"
 script = "${installDir}/${name}/src/redis-server"
-

--- a/services/redis/redis_install.groovy
+++ b/services/redis/redis_install.groovy
@@ -14,10 +14,13 @@
 * limitations under the License.
 *******************************************************************************/
 config = new ConfigSlurper().parse(new File("redis-service.properties").toURL())
-
-new AntBuilder().sequential {
-	mkdir(dir:config.installDir)
-	get(src:config.downloadPath, dest:"${config.installDir}/${config.zipName}", skipexisting:true)
-	untar(src:"${config.installDir}/${config.zipName}", dest:config.installDir, compression:"gzip")
-	exec(executable:"make", dir:"${config.installDir}/${config.name}", osfamily:"unix")
-}	
+def executable = new File(config.script)
+if (!executable.exists()) {
+	new AntBuilder().sequential {
+		mkdir(dir:config.installDir)
+		get(src:config.downloadPath, dest:"${config.installDir}/${config.zipName}", skipexisting:true)
+		untar(src:"${config.installDir}/${config.zipName}", dest:config.installDir, compression:"gzip")
+		chmod(file:"${config.installDir}/${config.name}/src/mkreleasehdr.sh", perm:"u+rx")
+		exec(executable:"make", dir:"${config.installDir}/${config.name}")
+	}	
+}


### PR DESCRIPTION
Hi,

I hope this is a useful contribution. 
To make the Redis service work on my Mac OS X 10.9.1 environment, I made the following changes:
- Updated reference to Redis v 2.8.6.
- Changed downloadPath to point to the new URL for Redis.
- Placed a check to avoid recompiling Redis.
- Added a chmod task to make mkreleasehdr.sh executable for _make_ to work on Mac OS X 10.9.1 with Cloudify 2.7.0 GA (build 5996). 

This should work on other Unix platforms. Further testing required on discrete platforms.

Kind regards,
Fuzz.
